### PR TITLE
[BUILD] Add Open Source Review Toolkit Workflow

### DIFF
--- a/.github/workflows/oss-review-toolkit.yml
+++ b/.github/workflows/oss-review-toolkit.yml
@@ -1,0 +1,27 @@
+name: Open Source Software Review Toolkit (ORT)
+
+on:
+    workflow_dispatch:
+
+    push:
+        branches: [ main ]
+        tags:
+            - "[0-9]+.[0-9]+.[0-9]+"
+
+    schedule:
+        # On the first day of each month at 1:30AM.
+        - cron:  '30 1 1 * *'
+
+
+jobs:
+    oss-review-toolkit:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: "Use HTTPS instead of SSH for Git cloning"
+              run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
+
+            - name: "Checkout repository"
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            
+            - name: "Run ORT GitHub Action"
+              uses: oss-review-toolkit/ort-ci-github-action@9acdf1e56f1b42972b12274ae56c35bf70a5f65b # v1.01


### PR DESCRIPTION
This PR adds the Open Source Review Toolkit (ORT) workflow, which runs monthly, is automatically triggered when a version tag is pushed, and can be triggered manually.

The ORT worklow creates a bunch of artifacts, among them are reports on found licences and security issues found.