### PR TITLE
[BUILD] Bump setup-gradle action to version 4.3.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
             java-version: 17
         
         - name: "Setup Gradle"
-          uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
+          uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
         
         - name: "Run Kotlin linter ktlint"
           run: ./gradlew ktlintCheck
@@ -58,7 +58,7 @@ jobs:
                 java-version: 17
             
             - name: "Setup Gradle"
-              uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
+              uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
            
             - name: "Run unit tests with coverage"
               run: ./gradlew test
@@ -94,7 +94,7 @@ jobs:
               java-version: 17
             
           - name: "Setup Gradle"
-            uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6 # v4.2.2
+            uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
             with:
               build-scan-publish: true
               build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"


### PR DESCRIPTION
This PR bumps the ``setup-gradle`` action to ``4.3.0`` in all workflows that use it.