### PR TITLE
[DOC] Add telekom brand addition to header in AndroidTest

### DIFF
--- a/app/src/androidTest/java/com/telekom/citykey/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/telekom/citykey/ExampleInstrumentedTest.kt
@@ -22,8 +22,8 @@
  * These elements are not considered part of the licensed Work or Derivative Works unless explicitly agreed otherwise. All elements must be altered, removed, or replaced before use or distribution. All rights to these materials are reserved, and Contributor accepts no liability for any infringing use. By using this repository, you agree to indemnify and hold harmless Contributor against any claims, costs, or damages arising from your use of the excluded elements.
  *
  * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
- * SPDX-License-Identifier: Apache-2.0
- * License-Filename: LICENSES/Apache-2.0.txt
+ * SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
+ * License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
  */
 
 package com.telekom.citykey


### PR DESCRIPTION
This `PR` adds the Deutsche Telekom brand addition to the license header in all `Kotlin` files within `AndroidTest`.

This `PR` adds the Deutsche Telekom brand addition to the license header in all `Kotlin` files within `AndroidTest`, and as a result makes the licensing situation clearar and is a `PR` that partially fixes the `REUSE` [error here](https://github.com/telekom/CityKey-Android/actions/runs/13518469582/job/37772154844).