### PR TITLE
[DOC] Add telekom brand addition to header in SmartApplication

### DIFF
--- a/app/src/main/java/com/telekom/citykey/SmartApplication.kt
+++ b/app/src/main/java/com/telekom/citykey/SmartApplication.kt
@@ -22,8 +22,8 @@
  * These elements are not considered part of the licensed Work or Derivative Works unless explicitly agreed otherwise. All elements must be altered, removed, or replaced before use or distribution. All rights to these materials are reserved, and Contributor accepts no liability for any infringing use. By using this repository, you agree to indemnify and hold harmless Contributor against any claims, costs, or damages arising from your use of the excluded elements.
  *
  * SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
- * SPDX-License-Identifier: Apache-2.0
- * License-Filename: LICENSES/Apache-2.0.txt
+ * SPDX-License-Identifier: Apache-2.0 AND LicenseRef-Deutsche-Telekom-Brand
+ * License-Filename: LICENSES/Apache-2.0.txt LICENSES/LicenseRef-Deutsche-Telekom-Brand.txt
  */
 
 package com.telekom.citykey


### PR DESCRIPTION
This `PR` adds the Deutsche Telekom brand addition to the license header in the`Kotlin` file `SmartApplication.kt`.

This `PR` adds the Deutsche Telekom brand addition to the license header in the `Kotlin` file `SmartApplication.kt`, and as a result makes the licensing situation clearer and is a `PR` that partially fixes the `REUSE` [error here](https://github.com/telekom/CityKey-Android/actions/runs/13518469582/job/37772154844).