### PR TITLE
[BUG] Fix ktlint errors in ExampleInstrubmentedTest

### DIFF
--- a/app/src/androidTest/java/com/telekom/citykey/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/telekom/citykey/ExampleInstrumentedTest.kt
@@ -30,7 +30,6 @@ package com.telekom.citykey
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
-import com.telekom.citykey.BuildConfig
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
This `PR` fixes the `ktlint` errors in `ExampleInstrubmentedTestkt`, and there should be no more `ktlint` errors after this `PR` is merged.

This `PR`fixes the `ktlint`errors `Trailing sapce(s)` and `Unncessary import`.