### PR TITLE
[BUILD]: Fix path variable for action upload-artifact in job ktlint

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
           uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
           with:
             name: ktlint-reports
-            path: /workspaces/CityKey-Android/app/build/reports/ktlint/
+            path: /home/runner/work/CityKey-Android/CityKey-Android/app/build/reports/ktlint/
             retention-days: 5
             compression-level: 9
 


### PR DESCRIPTION
This `PR` changes to `path` variable for action `upload-artifact` in job `ktlint`. After that, the upload should work.