### PR TITLE
[BUILD] - Delete REUSE.toml file

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,7 +1,0 @@
-# See https://reuse.software/spec-3.3/#reusetoml for specification
-version = 1
-
-[[annotations]]
-path = ["**"]
-SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
-SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Deleted the `REUSE.toml` file as we are adding relevant license headers to all files separately.