### PR TITLE
[DOC] Add copyright and license for all JSON files

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,7 @@
+# See https://reuse.software/spec-3.3/#reusetoml for specification
+version = 1
+
+[[annotations]]
+path = ["**/*.json"]
+SPDX-FileCopyrightText = "2024 Deutsche Telekom AG"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
This `PR` adds copyright and license information to all `.json` files via `REUSE.toml`.

`REUSE.toml` was deleted in commit d9b0ab8895f01876926744b21a76a7e924e142f1. Re-introducing `REUSE.toml` is necessary because `.json` does not support comments within the file.