### PR TITLE
[BUILD] Add top level permission restriction for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,10 @@ on:
       - './LICENSES'
 
 
+permissions:
+  contents: read
+
+  
 jobs:
   
     ktlint:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -22,7 +22,10 @@ on:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'
 
-permissions: read-all
+
+permissions:
+  contents: read
+
 
 jobs:
   analysis:

--- a/.github/workflows/oss-review-toolkit.yml
+++ b/.github/workflows/oss-review-toolkit.yml
@@ -16,6 +16,10 @@ on:
         # On the first day of each month at 1:30AM.
         - cron:  '30 1 1 * *'
 
+        
+permissions:
+  contents: read
+
 
 jobs:
     oss-review-toolkit:

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -7,6 +7,10 @@ name: REUSE Compliance Check
 on: [push, pull_request]
 
 
+permissions:
+  contents: read
+
+
 jobs:
   test-reuse-compliance:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This `PR` adds the top level permission for read to restrct the `GITHUB_TOKEN`.

This `PR` makes all workflows more secure by restricting the permission of the `GITHUB_TOKEN`, and does remediy security alerts such as [Token-Permissions](https://github.com/telekom/CityKey-Android/security/code-scanning/7), which look like
```
score is 0: no topLevel permission defined
Remediation tip: Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/github.com/telekom/CityKey-Android/reuse-compliance.yml/main?enable=permissions).
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead.
Click Remediation section below for further remediation help
```