### PR TITLE
[STYLE] Fix ktlint errors in AssetResponseMocker

### DIFF
--- a/network/src/main/java/com/telekom/citykey/network/mock/AssetResponseMocker.kt
+++ b/network/src/main/java/com/telekom/citykey/network/mock/AssetResponseMocker.kt
@@ -71,7 +71,6 @@ internal class AssetResponseMocker(
     inline fun <reified T> getOscaResponseListOf(
         fileName: String
     ): OscaResponse<List<T>> {
-
         val fileNameWithExtension = "$fileName.json"
 
         val listType = TypeToken.getParameterized(List::class.java, T::class.java)

--- a/network/src/main/java/com/telekom/citykey/network/mock/AssetResponseMocker.kt
+++ b/network/src/main/java/com/telekom/citykey/network/mock/AssetResponseMocker.kt
@@ -52,7 +52,6 @@ internal class AssetResponseMocker(
     inline fun <reified T> getOscaResponseOf(
         fileName: String
     ): OscaResponse<T> {
-
         val fileNameWithExtension = "$fileName.json"
 
         val oscaResponseType = TypeToken.getParameterized(OscaResponse::class.java, T::class.java)

--- a/network/src/main/java/com/telekom/citykey/network/mock/AssetResponseMocker.kt
+++ b/network/src/main/java/com/telekom/citykey/network/mock/AssetResponseMocker.kt
@@ -69,7 +69,7 @@ internal class AssetResponseMocker(
      * @return the data of type [List] of [T], parsed from Assets JSON file with name "[fileName].json", wrapped in [OscaResponse]
      */
     inline fun <reified T> getOscaResponseListOf(
-        fileName: String,
+        fileName: String
     ): OscaResponse<List<T>> {
 
         val fileNameWithExtension = "$fileName.json"


### PR DESCRIPTION
This `PR` fixes the [errors](https://github.com/telekom/CityKey-Android/actions/runs/14703685582/job/41258555524) from the linter `ktlint` reported in `AssetResponseMocker `.