### PR TITLE
[STYLE] Fix ktlint errors in waste_calendar

### DIFF
--- a/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
+++ b/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
@@ -97,9 +97,11 @@ class DATPickupsRemoteViewService : RemoteViewsService() {
 
         private fun populateWastePickupData(view: RemoteViews, pickup: WasteItems.WasteItem) {
             view.setImageViewResource(R.id.pickupIcon, R.drawable.ic_waste_trash_icon)
+            
             val wasteIconColorInt = if (resources.isDarkMode) {
                 ColorUtils.invertIfDark(pickup.wasteIconColorInt)
             } else pickup.wasteIconColorInt
+            
             view.setInt(
                 R.id.pickupIcon, "setColorFilter",
                 wasteIconColorInt

--- a/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
+++ b/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
@@ -100,7 +100,9 @@ class DATPickupsRemoteViewService : RemoteViewsService() {
             
             val wasteIconColorInt = if (resources.isDarkMode) {
                 ColorUtils.invertIfDark(pickup.wasteIconColorInt)
-            } else pickup.wasteIconColorInt
+            } else {
+                pickup.wasteIconColorInt
+            }
             
             view.setInt(
                 R.id.pickupIcon, "setColorFilter",

--- a/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
+++ b/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
@@ -51,7 +51,6 @@ class DATPickupsRemoteViewService : RemoteViewsService() {
     private val widgetInteractor: WidgetInteractor by inject()
 
     override fun onGetViewFactory(intent: Intent?): RemoteViewsFactory {
-
         return WasteMediumItemViewsFactory(applicationContext, widgetInteractor.pickups)
     }
 

--- a/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
+++ b/app/src/main/java/com/telekom/citykey/view/widget/waste_calendar/medium_widget/DATPickupsRemoteViewService.kt
@@ -105,7 +105,8 @@ class DATPickupsRemoteViewService : RemoteViewsService() {
             }
             
             view.setInt(
-                R.id.pickupIcon, "setColorFilter",
+                R.id.pickupIcon,
+                "setColorFilter",
                 wasteIconColorInt
             )
             view.setInt(


### PR DESCRIPTION
This `PR` fixes the [errors](https://github.com/telekom/CityKey-Android/actions/runs/14703685582/job/41258555524) from the linter `ktlint` reported in `waste_calendar` - with the exception of package name errors, e.g. `waste_calendar` is not allowed.