### PR TITLE
[BUILD] Pin dev-container with image digest to improve security

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,8 @@
 # SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
 # SPDX-License-Identifier: CC0-1.0
 
+# Pinning the image digest ensures reproducibility and security by preventing unintentional updates.
+# The digest corresponds to the .NET 8.0-noble version at the time of writing.
 ARG VARIANT="8.0-noble@sha256:78e4d6aa58fbc816a2a656768b0bda653780710c0dadab1b2c9e53e1c747aaf3"
 FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
 # SPDX-License-Identifier: CC0-1.0
 
-ARG VARIANT="8.0-noble"
+ARG VARIANT="8.0-noble@sha256:78e4d6aa58fbc816a2a656768b0bda653780710c0dadab1b2c9e53e1c747aaf3"
 FROM mcr.microsoft.com/devcontainers/dotnet:${VARIANT}
 
 # Set up machine requirements to build the repo


### PR DESCRIPTION
This `PR` pins the devoncontainer via the image digest to improve security.

See  at the [.NET Development Container Images](https://mcr.microsoft.com/en-us/artifact/mar/devcontainers/dotnet/tags) registry for the digest.